### PR TITLE
[refactor]. update config to reduce overheads of spark.

### DIFF
--- a/KSE.sh
+++ b/KSE.sh
@@ -74,6 +74,15 @@ start() {
     --log-opt max-file=9 \
     docker.baozou.com/baozou/spark:1.5-py3.4 \
     spark-submit --master spark://${SparkMasterURL} \
+    --conf spark.executor.logs.rolling.maxRetainedFiles=3 \
+    --conf spark.executor.logs.rolling.maxSize=10000000 \
+    --conf spark.executor.logs.rolling.strategy=size \
+    --conf "spark.serializer=org.apache.spark.serializer.KryoSerializer" \
+    --conf "spark.cleaner.ttl=300" \
+    --conf "spark.executor.extraJavaOptions=-XX:+UseConcMarkSweepGC" \
+    --driver-java-options "-XX:+UseConcMarkSweepGC" \
+    --driver-memory 2G \
+    --files /data/KSE/log4j.properties \
     --jars /opt/spark/jars/spark-streaming-kafka-assembly.jar,/opt/spark/jars/elasticsearch-hadoop.jar \
     --py-files /data/KSE/adapters.py /data/KSE/submit.py kafka ${ZooKeeperURL} bzfun-app-log ${elasticsearchURL} \
     2>&1

--- a/KSE.test.sh
+++ b/KSE.test.sh
@@ -43,6 +43,11 @@ start() {
     --log-opt max-file=9 \
     docker.baozou.com/baozou/spark:1.5-py3.4 \
     spark-submit --master local[*] \
+    --conf "spark.serializer=org.apache.spark.serializer.KryoSerializer" \
+    --conf "spark.cleaner.ttl=300" \
+    --conf "spark.executor.extraJavaOptions=-XX:+UseConcMarkSweepGC" \
+    --driver-java-options "-XX:+UseConcMarkSweepGC" \
+    --files /data/KSE/log4j.properties \
     --jars /opt/spark/jars/spark-streaming-kafka-assembly.jar,/opt/spark/jars/elasticsearch-hadoop.jar \
     --py-files /data/KSE/adapters.py /data/KSE/submit.py network 172.17.42.1 9999 ${elasticsearchURL} \
     2>&1

--- a/log4j.properties
+++ b/log4j.properties
@@ -1,0 +1,12 @@
+# Set everything to be logged to the console
+log4j.rootCategory=WARN, console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
+
+# Settings to quiet third party logs that are too verbose
+log4j.logger.org.spark-project.jetty=WARN
+log4j.logger.org.spark-project.jetty.util.component.AbstractLifeCycle=ERROR
+log4j.logger.org.apache.spark.repl.SparkIMain$exprTyper=WARN
+log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=WARN

--- a/submit.py
+++ b/submit.py
@@ -53,15 +53,18 @@ class Config(object):
     def getSparkConf(self):
         conf = SparkConf()
         conf.setAppName(self.PROJECT_NAME)
-        # conf.setMaster(self.MASTER)
-        # conf.set("spark.executor.memory", self.EXECUTOR_MEMORY)
+        conf.set(
+            "spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+        conf.set("spark.cleaner.ttl", "300")
         # es
         conf.set("es.index.auto.create", "true")
         conf.set("es.nodes", self.ES_NODES)
         return conf
 
     def getStreamingContext(self, sc):
-        return StreamingContext(sc, self.INTERVAL)
+        ssc = StreamingContext(sc, self.INTERVAL)
+        ssc.remember(240)
+        return ssc
 
 
 ###############
@@ -160,7 +163,7 @@ def dealeach(adapter, lines, conf):
 
 def deal(lines, conf):
     adapters = [
-        AllAdapters.BaseAdapter(),
+        # AllAdapters.BaseAdapter(),
         AllAdapters.searchClickAdapter(),
         AllAdapters.recommendclickAdapter(),
         AllAdapters.playonlineAdapter(),


### PR DESCRIPTION
#6

10: 增加启动脚本中--driver-memory  
11: 增加启动脚本中--files  
12: 增加启动脚本--conf，增加代码中conf.set（注：然而根据文档，Python仿佛使用Pickle做序列化（[文档](https://spark.apache.org/docs/latest/programming-guide.html#rdd-persistence)），姑且先设置着）  
17: 增加启动脚本中--conf ttl，增加代码中conf.set(ttl)，增加ssc.remember，启用并发标志GC，增加启动脚本--conf GC和--driver-java-options GC
