### PR TITLE
[refactor]. change main logic.

### DIFF
--- a/KSE.sh
+++ b/KSE.sh
@@ -14,6 +14,7 @@ WebuiPort=8080
 # set data dir
 KSEInclude=${CurDir}/jars
 KSELogs='/data/KSE/logs'
+KSECheckpoint='/data/KSE/checkpoint'
 
 update_images() {
   # pull spark-cluster docker image
@@ -27,6 +28,7 @@ start() {
   update_images
 
   mkdir -p ${KSELogs}
+  mkdir -p ${KSECheckpoint}
 
   # if previous docker container is not exit, kill it
   docker kill KSE 2>/dev/null
@@ -69,6 +71,7 @@ start() {
     -v ${KSEInclude}:/opt/spark/jars \
     -v ${CurDir}:/data/KSE \
     -v ${KSELogs}:/data/logs/KSE \
+    -v ${KSECheckpoint}:/data/checkpoint/KSE \
     --net=host \
     --log-opt max-size=100m \
     --log-opt max-file=9 \
@@ -145,7 +148,8 @@ info() {
 }
 
 destroy() {
-  echo "destroy..."
+  rm -r ${KSELogs}
+  rm -r ${KSECheckpoint}
 }
 
 ##################
@@ -160,9 +164,12 @@ case "$1" in
     stop
     start
     ;;
-  destroy) destroy ;;
+  destroy) 
+    stop
+    destroy
+    ;;
   *)
-    echo "Usage: ./KSE.sh start|stop|info|restart"
+    echo "Usage: ./KSE.sh start|stop|info|restart|destroy"
     exit 1
     ;;
 esac


### PR DESCRIPTION
#6

1: 当前代码已经注意不使用引用传参的方式。  
2: 并没有使用foreach，DStream中使用foreachRdd。  
3: 在flatMap之后增加persist()，这样可以防止rdd重新计算lineage，并且重构前是将所有原始数据缓存在内存，而现在是将第一次筛选后的数据缓存，在除去BaseAdapter之后，可以大大减小内存使用量。  
5: 当前使用的是map()->flatMap().persist()->filter().map()->countByKey()的逻辑，这一套逻辑更加科学。
